### PR TITLE
fix mxCellTracker param

### DIFF
--- a/src/mxgraph-typings.d.ts
+++ b/src/mxgraph-typings.d.ts
@@ -20464,7 +20464,7 @@ export module mxgraph {
      * <mxCellMarker.getCell>.
      */
     export class mxCellTracker extends mxCellMarker {
-        constructor(graph: any, color: any, funct: any);
+        constructor(graph: mxGraph, color?: string, funct?: any);
         /**
          * Ignores the event. The event is not consumed.
          */


### PR DESCRIPTION
- color is optional but the default is blue on mxGraph
- function is optional
- change type graph to mxGraph